### PR TITLE
Fix minor issues in sc_array

### DIFF
--- a/array/array_test.c
+++ b/array/array_test.c
@@ -323,11 +323,31 @@ void fail_test()
 	sc_array_del_unordered(&arr, 0);
 	assert(arr.elems[0] == 4);
 	assert(sc_array_size(&arr) == 4);
+
+	size_t cap = arr.cap;
 	sc_array_clear(&arr);
+	assert(cap == arr.cap);
 	assert(sc_array_size(&arr) == 0);
 	sc_array_add(&arr, 10);
 	assert(sc_array_size(&arr) == 1);
 	assert(arr.elems[0] == 10);
+
+	sc_array_clear(&arr);
+	assert(arr.size == 0);
+	assert(arr.cap == cap);
+
+	for (int i = 0; i < 100; i++) {
+		sc_array_add(&arr, i * 514);
+	}
+
+	for (int i = 0; i < 100; i++) {
+		assert(sc_array_at(&arr, i) == i * 514);
+	}
+
+	cap = arr.cap;
+	sc_array_clear(&arr);
+	assert(arr.size == 0);
+	assert(arr.cap == cap);
 
 	sc_array_term(&arr);
 }

--- a/array/sc_array.h
+++ b/array/sc_array.h
@@ -117,7 +117,6 @@
  */
 #define sc_array_clear(a)                                                      \
 	do {                                                                   \
-		(a)->cap = 0;                                                  \
 		(a)->size = 0;                                                 \
 		(a)->oom = false;                                              \
 	} while (0)

--- a/array/sc_array.h
+++ b/array/sc_array.h
@@ -148,10 +148,12 @@
  */
 #define sc_array_del(a, i)                                                     \
 	do {                                                                   \
-		assert((i) < (a)->size);                                       \
-		const size_t _cnt = (a)->size - (i) -1;                        \
+                size_t idx = (i);                                              \
+		assert(idx < (a)->size);                                       \
+                                                                               \
+		const size_t _cnt = (a)->size - (idx) - 1;                     \
 		if (_cnt > 0) {                                                \
-			memmove(&((a)->elems[i]), &((a)->elems[(i) + 1]),      \
+			memmove(&((a)->elems[idx]), &((a)->elems[idx + 1]),    \
 				_cnt * sizeof(*((a)->elems)));                 \
 		}                                                              \
 		(a)->size--;                                                   \
@@ -169,8 +171,9 @@
  */
 #define sc_array_del_unordered(a, i)                                           \
 	do {                                                                   \
-		assert((i) < (a)->size);                                       \
-		(a)->elems[i] = (a)->elems[(--(a)->size)];                     \
+                size_t idx = (i);                                              \
+		assert(idx < (a)->size);                                       \
+		(a)->elems[idx] = (a)->elems[(--(a)->size)];                   \
 	} while (0)
 
 /**


### PR DESCRIPTION
Fix minor issues in sc_array

- Previously, in sc_array_clear(), `cap` was set to zero by mistake. This bug caused an extra realloc() call on the next add call. 
- Some macro parameters in sc_array used to appear twice in the code. That can have a side effect: 
```
#define sc_array_del(a, i)                                                     \
	do {                                                                   \
		assert((i) < (a)->size);                                       \
		const size_t _cnt = (a)->size - (i) -1;                        \
		if (_cnt > 0) {                                                \
			memmove(&((a)->elems[i]), &((a)->elems[(i) + 1]),      \
				_cnt * sizeof(*((a)->elems)));                 \
		}                                                              \
		(a)->size--;                                                   \
	} while (0)
```

Consider this usage: `sc_array_del(arr, val++);`

`val` will be incremented multiple time. Compilers (most if not all) will warn about this but looks like some people don't enable warnings :) Fixed the issue by pulling the variable to a local variable first. 