### PR TITLE
Function sc_sock_connect() picks wrong address faimily

### DIFF
--- a/socket/sc_sock.c
+++ b/socket/sc_sock.c
@@ -533,6 +533,7 @@ int sc_sock_connect(struct sc_sock *s, const char *dst_addr,
 
 	for (int i = 0; i < 2; i++) {
 		for (p = sinfo; p != NULL; p = p->ai_next) {
+			// Try same family addresses in the first iteration.                        
 			if ((i == 0) ^ (p->ai_family == family)) {
 				continue;
 			}

--- a/socket/sc_sock.c
+++ b/socket/sc_sock.c
@@ -533,7 +533,7 @@ int sc_sock_connect(struct sc_sock *s, const char *dst_addr,
 
 	for (int i = 0; i < 2; i++) {
 		for (p = sinfo; p != NULL; p = p->ai_next) {
-			if (i == 0 ^ p->ai_family == family) {
+			if ((i == 0) ^ (p->ai_family == family)) {
 				continue;
 			}
 

--- a/socket/sc_sock.c
+++ b/socket/sc_sock.c
@@ -510,6 +510,7 @@ int sc_sock_connect(struct sc_sock *s, const char *dst_addr,
 		    const char *dst_port, const char *src_addr,
 		    const char *src_port)
 {
+	int family = s->family;
 	int rc, rv = 0;
 	sc_sock_int fd;
 	void *tmp;
@@ -520,7 +521,7 @@ int sc_sock_connect(struct sc_sock *s, const char *dst_addr,
 		.ai_socktype = SOCK_STREAM,
 	};
 
-	if (s->family == AF_UNIX) {
+	if (family == AF_UNIX) {
 		return sc_sock_connect_unix(s, dst_addr);
 	}
 
@@ -530,52 +531,58 @@ int sc_sock_connect(struct sc_sock *s, const char *dst_addr,
 		return -1;
 	}
 
-	for (p = sinfo; p != NULL; p = p->ai_next) {
-		fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
-		if (fd == SC_INVALID) {
-			continue;
-		}
+	for (int i = 0; i < 2; i++) {
+		for (p = sinfo; p != NULL; p = p->ai_next) {
+			if (i == 0 ^ p->ai_family == family) {
+				continue;
+			}
 
-		s->family = p->ai_family;
-		s->fdt.fd = fd;
+			fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+			if (fd == SC_INVALID) {
+				continue;
+			}
 
-		rc = sc_sock_set_blocking(s, s->blocking);
-		if (rc != 0) {
-			goto error;
-		}
+			s->family = p->ai_family;
+			s->fdt.fd = fd;
 
-		tmp = (void *) &(int){1};
-		rc = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, tmp, sizeof(int));
-		if (rc != 0) {
-			goto error;
-		}
-
-		rc = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, tmp, sizeof(int));
-		if (rc != 0) {
-			goto error;
-		}
-
-		if (src_addr || src_port) {
-			rc = sc_sock_bind_src(s, src_addr, src_port);
+			rc = sc_sock_set_blocking(s, s->blocking);
 			if (rc != 0) {
-				goto bind_error;
-			}
-		}
-
-		rc = connect(s->fdt.fd, p->ai_addr, (socklen_t) p->ai_addrlen);
-		if (rc != 0) {
-			if (!s->blocking && (sc_sock_err() == SC_EINPROGRESS ||
-					     sc_sock_err() == SC_EAGAIN)) {
-				errno = EAGAIN;
-				rv = -1;
-				goto end;
+				goto error;
 			}
 
-			sc_sock_close(s);
-			continue;
-		}
+			tmp = (void *) &(int){1};
+			rc = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, tmp, sizeof(int));
+			if (rc != 0) {
+				goto error;
+			}
 
-		goto end;
+			rc = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, tmp, sizeof(int));
+			if (rc != 0) {
+				goto error;
+			}
+
+			if (src_addr || src_port) {
+				rc = sc_sock_bind_src(s, src_addr, src_port);
+				if (rc != 0) {
+					goto bind_error;
+				}
+			}
+
+			rc = connect(fd, p->ai_addr, (socklen_t) p->ai_addrlen);
+			if (rc != 0) {
+				if (!s->blocking && (sc_sock_err() == SC_EINPROGRESS ||
+							 sc_sock_err() == SC_EAGAIN)) {
+					errno = EAGAIN;
+					rv = -1;
+					goto end;
+				}
+
+				sc_sock_close(s);
+				continue;
+			}
+
+			goto end;
+		}
 	}
 
 error:


### PR DESCRIPTION
Connecting in non-blocking mode `AF_INET6` socket with `sc_sock_connect("localhost")` where both IPv4 and IPv6 addresses are assigned to "localhost" but the server listens on IPv6 only.

It fails with `Connection refused` because `getaddrinfo` looks for any available address with `AF_UNSPEC` and wrongly picks IPv4. And since it is non-blocking mode it can not retry after the failure. 

This change makes `sc_sock_connect()` give more respect to the configured socket family: the first iteration we try to connect to addresses with the matching family, the second iteration we try to connect to the rest.