### PR TITLE
sc_sock: Linux to Windows cross-compilation

### DIFF
--- a/socket/sc_sock.c
+++ b/socket/sc_sock.c
@@ -49,7 +49,7 @@
 #if defined(_WIN32) || defined(_WIN64)
 #include <afunix.h>
 #include <assert.h>
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 
 #pragma warning(disable : 4996)
 #define sc_close(n) closesocket(n)

--- a/socket/sc_sock.h
+++ b/socket/sc_sock.h
@@ -46,7 +46,7 @@
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 #include <windows.h>
 #include <winsock2.h>
 


### PR DESCRIPTION
Windows NTFS is usually case insensitive, but on Linux this change is needed to build with MinGW-w64 toolchain.