### PR TITLE
sc_sock: use dense events array instead of a sparse one on Windows

### DIFF
--- a/socket/sc_sock.c
+++ b/socket/sc_sock.c
@@ -1612,6 +1612,8 @@ int sc_sock_poll_del(struct sc_sock_poll *p, struct sc_sock_fd *fdt,
 		}
 
 		p->events[p->count].fd = SC_INVALID;
+		p->data[p->count] = NULL;
+
 		fdt->index = -1;
 	} else {
 		p->events[fdt->index].events = 0;

--- a/socket/sc_sock.c
+++ b/socket/sc_sock.c
@@ -1607,11 +1607,11 @@ int sc_sock_poll_del(struct sc_sock_poll *p, struct sc_sock_fd *fdt,
 
 		// Move the last element in place of the removed one.
 		if (fdt->index < p->count) {
-			p->events[fdt->index] = p->events[fdt->count];
-			p->data[fdt->index] = p->data[fdt->count];
+			p->events[fdt->index] = p->events[p->count];
+			p->data[fdt->index] = p->data[p->count];
 		}
 
-		p->events[fdt->count].fd = SC_INVALID;
+		p->events[p->count].fd = SC_INVALID;
 		fdt->index = -1;
 	} else {
 		p->events[fdt->index].events = 0;


### PR DESCRIPTION
Optimization: 
- O(1) `sc_sock_poll_add`
- work with only `count` events instead of `cap`
- `events` array is not sparse anymore
- `sc_sock_poll_wait` returns 0 if no events were actually triggered 