### PR TITLE
sc_array: Include string.h for memmove()

### DIFF
--- a/array/sc_array.h
+++ b/array/sc_array.h
@@ -33,7 +33,7 @@
 #define SC_ARRAY_H
 
 #include <assert.h>
-#include <memory.h>
+#include <string.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
This is just to silence compiler warning for mingw build