### PR TITLE
Zig CC cross-compilation support for Windows on Linux host.

### DIFF
--- a/.github/workflows/.ubuntu.yml
+++ b/.github/workflows/.ubuntu.yml
@@ -130,3 +130,24 @@ jobs:
           cmake .. -DCMAKE_C_FLAGS=-m32 -DSANITIZER=undefined
           make -j
           make check
+  ubuntu-zig-windows:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'push') ||
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'tezc/sc')) && !contains(github.event.inputs.skip, 'zig-windows')
+    name: Zig Windows
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - name: build
+        run: |
+          sudo apt update
+          sudo apt-get install cmake curl tar
+          mkdir build-debug && cd build-debug
+          export ZIG=zig-linux-x86_64-0.12.0-dev.1834+f36ac227b
+          curl -o zig.tar.xz "https://ziglang.org/builds/$ZIG.tar.xz"
+          tar -xf zig.tar.xz
+          export CC="$(pwd)/$ZIG/zig cc -target x86_64-windows"
+          cmake .. -DCMAKE_SYSTEM_NAME=Windows
+          make -j

--- a/buffer/buf_test.c
+++ b/buffer/buf_test.c
@@ -617,7 +617,7 @@ void fail_test(void)
 	sc_buf_term(&buf);
 }
 #else
-void fail_test()
+void fail_test(void)
 {
 }
 #endif

--- a/condition/cond_test.c
+++ b/condition/cond_test.c
@@ -280,7 +280,7 @@ void fail_test(void)
 }
 
 #else
-void fail_test()
+void fail_test(void)
 {
 }
 #endif

--- a/condition/sc_cond.c
+++ b/condition/sc_cond.c
@@ -40,7 +40,10 @@
 #include <string.h>
 
 #if defined(_WIN32) || defined(_WIN64)
+
+#ifdef _MSC_VER
 #pragma warning(disable : 4996)
+#endif
 
 int sc_cond_init(struct sc_cond *c)
 {

--- a/heap/heap_test.c
+++ b/heap/heap_test.c
@@ -239,7 +239,7 @@ void fail_test(void)
 	sc_heap_term(&heap);
 }
 #else
-void fail_test()
+void fail_test(void)
 {
 }
 #endif

--- a/ini/ini_test.c
+++ b/ini/ini_test.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#ifdef _MSC_VER
 #pragma warning(disable : 4996)
 #endif
 

--- a/ini/sc_ini.c
+++ b/ini/sc_ini.c
@@ -37,7 +37,7 @@
 #include <ctype.h>
 #include <string.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#ifdef _MSC_VER
 #pragma warning(disable : 4996)
 #endif
 

--- a/logger/log_test.c
+++ b/logger/log_test.c
@@ -5,7 +5,7 @@
 #include <stdarg.h>
 #include <time.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#ifdef _MSC_VER
 #pragma warning(disable : 4996)
 #endif
 

--- a/logger/sc_log.c
+++ b/logger/sc_log.c
@@ -73,7 +73,10 @@ thread_local char sc_name[32] = "Thread";
 
 #if defined(_WIN32) || defined(_WIN64)
 
+#ifdef _MSC_VER
 #pragma warning(disable : 4996)
+#endif
+
 #define strcasecmp _stricmp
 #define localtime_r(a, b) (localtime_s(b, a) == 0 ? b : NULL)
 #include <windows.h>

--- a/memory-map/mmap_test.c
+++ b/memory-map/mmap_test.c
@@ -297,7 +297,7 @@ void fail_test(void)
 	fail_posix_fallocate = UINT32_MAX;
 }
 #else
-void fail_test()
+void fail_test(void)
 {
 }
 #endif

--- a/memory-map/sc_mmap.c
+++ b/memory-map/sc_mmap.c
@@ -43,7 +43,9 @@
 #include <io.h>
 #include <stdint.h>
 
+#ifdef _MSC_VER
 #pragma warning(disable : 4996)
+#endif
 
 static void sc_mmap_errstr(struct sc_mmap *m)
 {

--- a/signal/CMakeLists.txt
+++ b/signal/CMakeLists.txt
@@ -12,6 +12,10 @@ add_library(
 
 target_include_directories(sc_signal PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
+if (CMAKE_SYSTEM_NAME MATCHES Windows)
+    target_link_libraries(sc_signal -lws2_32)
+endif()
+
 if (NOT CMAKE_C_COMPILER_ID MATCHES "MSVC")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -pedantic -Werror")
 endif ()
@@ -40,6 +44,10 @@ if (SC_BUILD_TEST)
     add_executable(${PROJECT_NAME}_test signal_test.c sc_signal.c)
 
     target_compile_options(${PROJECT_NAME}_test PRIVATE -DSC_SIZE_MAX=1400000ul)
+
+    if (CMAKE_SYSTEM_NAME MATCHES Windows)
+        target_link_libraries(${PROJECT_NAME}_test -lws2_32)
+    endif()
 
     check_c_source_compiles("
       #include <execinfo.h>

--- a/signal/sc_signal.c
+++ b/signal/sc_signal.c
@@ -52,7 +52,7 @@
 #endif
 
 #if defined(_WIN32)
-#include <WinSock2.h>
+#include <winsock2.h>
 volatile SOCKET sc_signal_shutdown_fd;
 #else
 volatile sig_atomic_t sc_signal_shutdown_fd;
@@ -202,13 +202,15 @@ int sc_signal_snprintf(char *buf, size_t sz, const char *fmt, ...)
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 #include <io.h>
 #include <signal.h>
 #include <windows.h>
 
+#ifdef _MSC_VER
 #pragma warning(disable : 4996)
 #pragma comment(lib, "Ws2_32.lib")
+#endif
 
 BOOL WINAPI sc_console_handler(DWORD type)
 {
@@ -297,9 +299,10 @@ void sc_signal_std_on_fatal(int sig)
 
 void sc_signal_std_on_shutdown(int type)
 {
+	(void)type;
 	sc_console_handler(CTRL_C_EVENT);
 }
-int sc_signal_init()
+int sc_signal_init(void)
 {
 	BOOL b;
 	sc_signal_log_fd = -1;

--- a/signal/sc_signal.h
+++ b/signal/sc_signal.h
@@ -47,7 +47,7 @@
  * e.g., CTRL+C to shutdown, twice CTRL+C means 'I don't want to wait anything'.
  */
 #if defined(_WIN32)
-#include <WinSock2.h>
+#include <winsock2.h>
 extern volatile SOCKET sc_signal_shutdown_fd;
 #else
 extern volatile sig_atomic_t sc_signal_shutdown_fd;

--- a/socket/CMakeLists.txt
+++ b/socket/CMakeLists.txt
@@ -12,6 +12,10 @@ add_library(
 
 target_include_directories(sc_socket PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
+if (CMAKE_SYSTEM_NAME MATCHES Windows)
+    target_link_libraries(sc_socket -lws2_32)
+endif()
+
 if (NOT CMAKE_C_COMPILER_ID MATCHES "MSVC")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -pedantic -pthread -Werror")
 endif ()
@@ -40,6 +44,10 @@ if (SC_BUILD_TEST)
     add_executable(${PROJECT_NAME}_test sock_test.c sc_sock.c)
 
     target_compile_options(${PROJECT_NAME}_test PRIVATE -DSC_SIZE_MAX=300 -Dsc_fcntl=test_fcntl)
+
+    if (CMAKE_SYSTEM_NAME MATCHES Windows)
+        target_link_libraries(${PROJECT_NAME}_test -lws2_32)
+    endif()
 
     if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND SC_USE_WRAP)
         if ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR

--- a/socket/sock_test.c
+++ b/socket/sock_test.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <errno.h>
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <synchapi.h>
@@ -25,7 +26,6 @@ struct sc_thread {
 
 #else
 
-#include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdarg.h>

--- a/string/str_test.c
+++ b/string/str_test.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#ifdef _MSC_VER
 #pragma warning(disable : 4996)
 #endif
 

--- a/thread/sc_thread.c
+++ b/thread/sc_thread.c
@@ -39,7 +39,10 @@ void sc_thread_init(struct sc_thread *t)
 }
 
 #if defined(_WIN32) || defined(_WIN64)
+
+#ifdef _MSC_VER
 #pragma warning(disable : 4996)
+#endif
 
 #include <process.h>
 
@@ -85,7 +88,6 @@ int sc_thread_start(struct sc_thread *t, void *(*fn)(void *), void *arg)
 int sc_thread_join(struct sc_thread *t, void **ret)
 {
 	int rc = 0;
-	void *val = NULL;
 	DWORD rv;
 	BOOL brc;
 
@@ -105,7 +107,6 @@ int sc_thread_join(struct sc_thread *t, void **ret)
 		rc = -1;
 	}
 
-	val = t->ret;
 	t->id = 0;
 
 out:

--- a/uri/sc_uri.c
+++ b/uri/sc_uri.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#ifdef _MSC_VER
 #pragma warning(disable : 4996)
 #endif
 

--- a/uri/uri_test.c
+++ b/uri/uri_test.c
@@ -355,7 +355,7 @@ void fail_test(void)
 	fail_second_call = 0;
 }
 #else
-void fail_test()
+void fail_test(void)
 {
 }
 #endif


### PR DESCRIPTION
Was able to cross-compile everything on Linux for Windows with Zig. Some minor cleanup was needed.

It would be great to add a CI check for that. Here is the script:

```
export ZIG=zig-linux-x86_64-0.12.0-dev.1834+f36ac227b
rm -rf build && mkdir build && cd build
curl -o zig.tar.xz "https://ziglang.org/builds/$ZIG.tar.xz"
tar -xf zig.tar.xz
export CC="$(pwd)/$ZIG/zig cc -target x86_64-windows"
cmake -DCMAKE_SYSTEM_NAME=Windows ..
make
```
