### PR TITLE
WINE test for cross-compiled .exe binaries on Ubuntu

### DIFF
--- a/.github/workflows/.ubuntu.yml
+++ b/.github/workflows/.ubuntu.yml
@@ -143,7 +143,7 @@ jobs:
       - name: build
         run: |
           sudo apt update
-          sudo apt-get install cmake curl tar
+          sudo apt-get install cmake curl tar wine
           mkdir build-debug && cd build-debug
           export ZIG=zig-linux-x86_64-0.12.0-dev.1834+f36ac227b
           curl -o zig.tar.xz "https://ziglang.org/builds/$ZIG.tar.xz"
@@ -151,3 +151,24 @@ jobs:
           export CC="$(pwd)/$ZIG/zig cc -target x86_64-windows"
           cmake .. -DCMAKE_SYSTEM_NAME=Windows
           make -j
+          DISPLAY= wine ./array/sc_array_test.exe
+          DISPLAY= wine ./buffer/sc_buf_test.exe
+          DISPLAY= wine ./condition/sc_cond_test.exe
+          DISPLAY= wine ./crc32/sc_crc32_test.exe
+          DISPLAY= wine ./heap/sc_heap_test.exe
+          DISPLAY= wine ./ini/sc_ini_test.exe
+          DISPLAY= wine ./linked-list/sc_list_test.exe
+          DISPLAY= wine ./logger/sc_log_test.exe
+          DISPLAY= wine ./map/sc_map_test.exe
+          # DISPLAY= wine ./memory-map/sc_mmap_test.exe     <-- hangs
+          DISPLAY= wine ./mutex/sc_mutex_test.exe
+          DISPLAY= wine ./option/sc_option_test.exe
+          DISPLAY= wine ./queue/sc_queue_test.exe
+          DISPLAY= wine ./sc/sc_test.exe
+          DISPLAY= wine ./signal/sc_signal_test.exe
+          # DISPLAY= wine ./socket/sc_socket_test.exe       <-- Assertion failed
+          DISPLAY= wine ./string/sc_str_test.exe
+          DISPLAY= wine ./thread/sc_thread_test.exe
+          # DISPLAY= wine ./time/sc_time_test.exe           <-- wine: Unhandled illegal instruction
+          DISPLAY= wine ./timer/sc_timer_test.exe
+          DISPLAY= wine ./uri/sc_uri_test.exe

--- a/.github/workflows/.ubuntu.yml
+++ b/.github/workflows/.ubuntu.yml
@@ -143,7 +143,7 @@ jobs:
       - name: build
         run: |
           sudo apt update
-          sudo apt-get install cmake curl tar DISPLAY= wine
+          sudo apt-get install cmake curl tar wine
           mkdir build-debug && cd build-debug
           export ZIG=zig-linux-x86_64-0.12.0-dev.1834+f36ac227b
           curl -o zig.tar.xz "https://ziglang.org/builds/$ZIG.tar.xz"

--- a/.github/workflows/.ubuntu.yml
+++ b/.github/workflows/.ubuntu.yml
@@ -143,7 +143,7 @@ jobs:
       - name: build
         run: |
           sudo apt update
-          sudo apt-get install cmake curl tar wine
+          sudo apt-get install cmake curl tar DISPLAY= wine
           mkdir build-debug && cd build-debug
           export ZIG=zig-linux-x86_64-0.12.0-dev.1834+f36ac227b
           curl -o zig.tar.xz "https://ziglang.org/builds/$ZIG.tar.xz"
@@ -151,25 +151,45 @@ jobs:
           export CC="$(pwd)/$ZIG/zig cc -target x86_64-windows"
           cmake .. -DCMAKE_SYSTEM_NAME=Windows
           make -j
-          export DISPLAY=
-          echo sc_array_test && wine ./array/sc_array_test.exe
-          echo sc_buf_test && wine ./buffer/sc_buf_test.exe
-          echo sc_cond_test && wine ./condition/sc_cond_test.exe
-          echo sc_crc32_test && wine ./crc32/sc_crc32_test.exe
-          echo sc_heap_test && wine ./heap/sc_heap_test.exe
-          echo sc_ini_test && wine ./ini/sc_ini_test.exe
-          echo sc_list_test && wine ./linked-list/sc_list_test.exe
-          echo sc_log_test && wine ./logger/sc_log_test.exe
-          echo sc_map_test && wine ./map/sc_map_test.exe
-          # echo sc_mmap_test && wine ./memory-map/sc_mmap_test.exe     <-- hangs
-          echo sc_mutex_test && wine ./mutex/sc_mutex_test.exe
-          echo sc_option_test && wine ./option/sc_option_test.exe
-          echo sc_queue_test && wine ./queue/sc_queue_test.exe
-          echo sc_test && wine ./sc/sc_test.exe
-          echo sc_signal_test && wine ./signal/sc_signal_test.exe
-          # echo sc_socket_test && wine ./socket/sc_socket_test.exe     <-- Assertion failed
-          echo sc_str_test && wine ./string/sc_str_test.exe
-          echo sc_thread_test && wine ./thread/sc_thread_test.exe
-          # echo sc_time_test && wine ./time/sc_time_test.exe           <-- wine: Unhandled illegal instruction
-          echo sc_timer_test && wine ./timer/sc_timer_test.exe
-          echo sc_uri_test && wine ./uri/sc_uri_test.exe
+          echo "==============" && echo sc_array_test && echo "=============="
+          DISPLAY= wine ./array/sc_array_test.exe
+          echo "==============" && echo sc_buf_test && echo "=============="
+          DISPLAY= wine ./buffer/sc_buf_test.exe
+          echo "==============" && echo sc_cond_test && echo "=============="
+          DISPLAY= wine ./condition/sc_cond_test.exe
+          echo "==============" && echo sc_crc32_test && echo "=============="
+          DISPLAY= wine ./crc32/sc_crc32_test.exe
+          echo "==============" && echo sc_heap_test && echo "=============="
+          DISPLAY= wine ./heap/sc_heap_test.exe
+          echo "==============" && echo sc_ini_test && echo "=============="
+          DISPLAY= wine ./ini/sc_ini_test.exe
+          echo "==============" && echo sc_list_test && echo "=============="
+          DISPLAY= wine ./linked-list/sc_list_test.exe
+          echo "==============" && echo sc_log_test && echo "=============="
+          DISPLAY= wine ./logger/sc_log_test.exe
+          echo "==============" && echo sc_map_test && echo "=============="
+          DISPLAY= wine ./map/sc_map_test.exe
+          echo "==============" && echo sc_mmap_test && echo "=============="
+          # DISPLAY= wine ./memory-map/sc_mmap_test.exe                               <-- hangs
+          echo "==============" && echo sc_mutex_test && echo "=============="
+          DISPLAY= wine ./mutex/sc_mutex_test.exe
+          echo "==============" && echo sc_option_test && echo "=============="
+          DISPLAY= wine ./option/sc_option_test.exe
+          echo "==============" && echo sc_queue_test && echo "=============="
+          DISPLAY= wine ./queue/sc_queue_test.exe
+          echo "==============" && echo sc_test && echo "=============="
+          DISPLAY= wine ./sc/sc_test.exe
+          echo "==============" && echo sc_signal_test && echo "=============="
+          DISPLAY= wine ./signal/sc_signal_test.exe
+          echo "==============" && echo sc_socket_test && echo "=============="
+          # DISPLAY= wine ./socket/sc_socket_test.exe                                 <-- Assertion failed
+          echo "==============" && echo sc_str_test && echo "=============="
+          DISPLAY= wine ./string/sc_str_test.exe
+          echo "==============" && echo sc_thread_test && echo "=============="
+          DISPLAY= wine ./thread/sc_thread_test.exe
+          echo "==============" && echo sc_time_test && echo "=============="
+          # DISPLAY= wine ./time/sc_time_test.exe                                     <-- wine: Unhandled illegal instruction
+          echo "==============" && echo sc_timer_test && echo "=============="
+          DISPLAY= wine ./timer/sc_timer_test.exe
+          echo "==============" && echo sc_uri_test && echo "=============="
+          DISPLAY= wine ./uri/sc_uri_test.exe

--- a/.github/workflows/.ubuntu.yml
+++ b/.github/workflows/.ubuntu.yml
@@ -142,8 +142,9 @@ jobs:
       - uses: actions/checkout@v2.1.0
       - name: build
         run: |
+          sudo dpkg --add-architecture i386
           sudo apt update
-          sudo apt-get install cmake curl tar wine
+          sudo apt-get install cmake curl tar wine wine32
           mkdir build-debug && cd build-debug
           export ZIG=zig-linux-x86_64-0.12.0-dev.1834+f36ac227b
           curl -o zig.tar.xz "https://ziglang.org/builds/$ZIG.tar.xz"
@@ -151,24 +152,24 @@ jobs:
           export CC="$(pwd)/$ZIG/zig cc -target x86_64-windows"
           cmake .. -DCMAKE_SYSTEM_NAME=Windows
           make -j
-          DISPLAY= wine ./array/sc_array_test.exe
-          DISPLAY= wine ./buffer/sc_buf_test.exe
-          DISPLAY= wine ./condition/sc_cond_test.exe
-          DISPLAY= wine ./crc32/sc_crc32_test.exe
-          DISPLAY= wine ./heap/sc_heap_test.exe
-          DISPLAY= wine ./ini/sc_ini_test.exe
-          DISPLAY= wine ./linked-list/sc_list_test.exe
-          DISPLAY= wine ./logger/sc_log_test.exe
-          DISPLAY= wine ./map/sc_map_test.exe
-          # DISPLAY= wine ./memory-map/sc_mmap_test.exe     <-- hangs
-          DISPLAY= wine ./mutex/sc_mutex_test.exe
-          DISPLAY= wine ./option/sc_option_test.exe
-          DISPLAY= wine ./queue/sc_queue_test.exe
-          DISPLAY= wine ./sc/sc_test.exe
-          DISPLAY= wine ./signal/sc_signal_test.exe
-          # DISPLAY= wine ./socket/sc_socket_test.exe       <-- Assertion failed
-          DISPLAY= wine ./string/sc_str_test.exe
-          DISPLAY= wine ./thread/sc_thread_test.exe
-          # DISPLAY= wine ./time/sc_time_test.exe           <-- wine: Unhandled illegal instruction
-          DISPLAY= wine ./timer/sc_timer_test.exe
-          DISPLAY= wine ./uri/sc_uri_test.exe
+          echo sc_array_test && DISPLAY= wine ./array/sc_array_test.exe
+          echo sc_buf_test && DISPLAY= wine ./buffer/sc_buf_test.exe
+          echo sc_cond_test && DISPLAY= wine ./condition/sc_cond_test.exe
+          echo sc_crc32_test && DISPLAY= wine ./crc32/sc_crc32_test.exe
+          echo sc_heap_test && DISPLAY= wine ./heap/sc_heap_test.exe
+          echo sc_ini_test && DISPLAY= wine ./ini/sc_ini_test.exe
+          echo sc_list_test && DISPLAY= wine ./linked-list/sc_list_test.exe
+          echo sc_log_test && DISPLAY= wine ./logger/sc_log_test.exe
+          echo sc_map_test && DISPLAY= wine ./map/sc_map_test.exe
+          # echo sc_mmap_test && DISPLAY= wine ./memory-map/sc_mmap_test.exe     <-- hangs
+          echo sc_mutex_test && DISPLAY= wine ./mutex/sc_mutex_test.exe
+          echo sc_option_test && DISPLAY= wine ./option/sc_option_test.exe
+          echo sc_queue_test && DISPLAY= wine ./queue/sc_queue_test.exe
+          echo sc_test && DISPLAY= wine ./sc/sc_test.exe
+          echo sc_signal_test && DISPLAY= wine ./signal/sc_signal_test.exe
+          # echo sc_socket_test && DISPLAY= wine ./socket/sc_socket_test.exe     <-- Assertion failed
+          echo sc_str_test && DISPLAY= wine ./string/sc_str_test.exe
+          echo sc_thread_test && DISPLAY= wine ./thread/sc_thread_test.exe
+          # echo sc_time_test && DISPLAY= wine ./time/sc_time_test.exe           <-- wine: Unhandled illegal instruction
+          echo sc_timer_test && DISPLAY= wine ./timer/sc_timer_test.exe
+          echo sc_uri_test && DISPLAY= wine ./uri/sc_uri_test.exe

--- a/.github/workflows/.ubuntu.yml
+++ b/.github/workflows/.ubuntu.yml
@@ -142,9 +142,8 @@ jobs:
       - uses: actions/checkout@v2.1.0
       - name: build
         run: |
-          sudo dpkg --add-architecture i386
           sudo apt update
-          sudo apt-get install cmake curl tar wine wine32
+          sudo apt-get install cmake curl tar wine
           mkdir build-debug && cd build-debug
           export ZIG=zig-linux-x86_64-0.12.0-dev.1834+f36ac227b
           curl -o zig.tar.xz "https://ziglang.org/builds/$ZIG.tar.xz"
@@ -152,24 +151,25 @@ jobs:
           export CC="$(pwd)/$ZIG/zig cc -target x86_64-windows"
           cmake .. -DCMAKE_SYSTEM_NAME=Windows
           make -j
-          echo sc_array_test && DISPLAY= wine ./array/sc_array_test.exe
-          echo sc_buf_test && DISPLAY= wine ./buffer/sc_buf_test.exe
-          echo sc_cond_test && DISPLAY= wine ./condition/sc_cond_test.exe
-          echo sc_crc32_test && DISPLAY= wine ./crc32/sc_crc32_test.exe
-          echo sc_heap_test && DISPLAY= wine ./heap/sc_heap_test.exe
-          echo sc_ini_test && DISPLAY= wine ./ini/sc_ini_test.exe
-          echo sc_list_test && DISPLAY= wine ./linked-list/sc_list_test.exe
-          echo sc_log_test && DISPLAY= wine ./logger/sc_log_test.exe
-          echo sc_map_test && DISPLAY= wine ./map/sc_map_test.exe
-          # echo sc_mmap_test && DISPLAY= wine ./memory-map/sc_mmap_test.exe     <-- hangs
-          echo sc_mutex_test && DISPLAY= wine ./mutex/sc_mutex_test.exe
-          echo sc_option_test && DISPLAY= wine ./option/sc_option_test.exe
-          echo sc_queue_test && DISPLAY= wine ./queue/sc_queue_test.exe
-          echo sc_test && DISPLAY= wine ./sc/sc_test.exe
-          echo sc_signal_test && DISPLAY= wine ./signal/sc_signal_test.exe
-          # echo sc_socket_test && DISPLAY= wine ./socket/sc_socket_test.exe     <-- Assertion failed
-          echo sc_str_test && DISPLAY= wine ./string/sc_str_test.exe
-          echo sc_thread_test && DISPLAY= wine ./thread/sc_thread_test.exe
-          # echo sc_time_test && DISPLAY= wine ./time/sc_time_test.exe           <-- wine: Unhandled illegal instruction
-          echo sc_timer_test && DISPLAY= wine ./timer/sc_timer_test.exe
-          echo sc_uri_test && DISPLAY= wine ./uri/sc_uri_test.exe
+          export DISPLAY=
+          echo sc_array_test && wine ./array/sc_array_test.exe
+          echo sc_buf_test && wine ./buffer/sc_buf_test.exe
+          echo sc_cond_test && wine ./condition/sc_cond_test.exe
+          echo sc_crc32_test && wine ./crc32/sc_crc32_test.exe
+          echo sc_heap_test && wine ./heap/sc_heap_test.exe
+          echo sc_ini_test && wine ./ini/sc_ini_test.exe
+          echo sc_list_test && wine ./linked-list/sc_list_test.exe
+          echo sc_log_test && wine ./logger/sc_log_test.exe
+          echo sc_map_test && wine ./map/sc_map_test.exe
+          # echo sc_mmap_test && wine ./memory-map/sc_mmap_test.exe     <-- hangs
+          echo sc_mutex_test && wine ./mutex/sc_mutex_test.exe
+          echo sc_option_test && wine ./option/sc_option_test.exe
+          echo sc_queue_test && wine ./queue/sc_queue_test.exe
+          echo sc_test && wine ./sc/sc_test.exe
+          echo sc_signal_test && wine ./signal/sc_signal_test.exe
+          # echo sc_socket_test && wine ./socket/sc_socket_test.exe     <-- Assertion failed
+          echo sc_str_test && wine ./string/sc_str_test.exe
+          echo sc_thread_test && wine ./thread/sc_thread_test.exe
+          # echo sc_time_test && wine ./time/sc_time_test.exe           <-- wine: Unhandled illegal instruction
+          echo sc_timer_test && wine ./timer/sc_timer_test.exe
+          echo sc_uri_test && wine ./uri/sc_uri_test.exe


### PR DESCRIPTION
The failures are most probably related to Wine quirks and not worth the investigation, but good to know that most of cross-compiled `.exe` binaries work even under Wine on Linux.