### PR TITLE
fix order of arguments in call to calloc

### DIFF
--- a/map/sc_map.c
+++ b/map/sc_map.c
@@ -108,7 +108,7 @@
 		v++;                                                           \
                                                                                \
 		*cap = v;                                                      \
-		t = sc_map_calloc(sizeof(*t), v + 1);                          \
+		t = sc_map_calloc(v + 1, sizeof(*t));                          \
 		return t ? &t[1] : NULL;                                       \
 	}                                                                      \
                                                                                \


### PR DESCRIPTION
GCC 14 reports it as `"error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]"` and compilation fails. The fix restores compilation on GCC 14.