### PR TITLE
uri: fix off-by-one in port bounds check

### DIFF
--- a/uri/sc_uri.c
+++ b/uri/sc_uri.c
@@ -94,7 +94,7 @@ struct sc_uri *sc_uri_create(const char *str)
 
 			errno = 0;
 			val = strtoul(ptr + 1, &parse_end, 10);
-			if (errno != 0 || val > 65536) {
+			if (errno != 0 || val > 65535) {
 				return NULL;
 			}
 

--- a/uri/uri_test.c
+++ b/uri/uri_test.c
@@ -246,11 +246,21 @@ void test13(void)
 	const char *f = "foo://user:password@example.com:-1/over/there?x#3";
 	const char *f2 = "foo://user:password@example.com:100000/over/"
 			 "there?x#3";
+	const char *f3 = "foo://example.com:65535";
+	const char *f4 = "foo://example.com:65536";
 
 	uri = sc_uri_create(f);
 	assert(uri == NULL);
 
 	uri = sc_uri_create(f2);
+	assert(uri == NULL);
+
+	uri = sc_uri_create(f3);
+	assert(uri != NULL);
+	assert(strcmp(uri->port, "65535") == 0);
+	sc_uri_destroy(uri);
+
+	uri = sc_uri_create(f4);
 	assert(uri == NULL);
 }
 


### PR DESCRIPTION
sc_uri_create() rejects ports strictly greater than 65536, which means the invalid port \`65536\` is currently accepted as valid. Valid TCP/UDP ports are 0-65535 (16-bit range), so the check should reject anything > 65535.

**Before:** \`http://host:65536/path\` -> accepted, port stored as \`"65536"\`
**After:** \`http://host:65536/path\` -> correctly rejected (\`sc_uri_create\` returns NULL)

\`65535\` and \`65537\` behavior is unchanged (still accepted / still rejected respectively).

Verified by compiling \`uri/sc_uri.c\` standalone and exercising \`sc_uri_create()\` on the boundary values, and by running the existing unmodified \`uri/uri_test.c\` against the patched file (exit code 0, all asserts pass — its existing port assertions use 8042/123/80/9090/1 and never exercised this 65535/65536 boundary).

One-line fix, no behavior change for any in-range or clearly-out-of-range port value.