### PR TITLE
string: handle empty replace pattern

### DIFF
--- a/string/sc_str.c
+++ b/string/sc_str.c
@@ -367,6 +367,10 @@ bool sc_str_replace(char **str, const char *replace, const char *with)
 	rep_len = strlen(replace);
 	with_len = strlen(with);
 
+	if (rep_len == 0) {
+		return true;
+	}
+
 	if (rep_len >= UINT32_MAX || with_len >= UINT32_MAX) {
 		return false;
 	}

--- a/string/str_test.c
+++ b/string/str_test.c
@@ -459,6 +459,11 @@ void test5(void)
 	assert(strcmp(s1, "longeRlongeR") == 0);
 	assert(sc_str_replace(&s1, "longeR", ""));
 	assert(strcmp(s1, "") == 0);
+	sc_str_set(&s1, "unchanged");
+	assert(sc_str_replace(&s1, "", "x"));
+	assert(strcmp(s1, "unchanged") == 0);
+	assert(sc_str_replace(&s1, "", ""));
+	assert(strcmp(s1, "unchanged") == 0);
 	sc_str_destroy(&s1);
 
 	s1 = sc_str_create("*test * test*");


### PR DESCRIPTION
`sc_str_replace()` passes an empty search pattern to `strstr()`. Since the pattern length is zero, neither replacement loop advances: the same-size path repeats indefinitely, while the resizing path repeats until the size guard rejects it.

Treat an empty search pattern as a successful no-op, consistent with the existing no-match behavior. Add coverage for both empty-to-nonempty and empty-to-empty replacements.

Tests:
- official CMake `sc_str_test` with AddressSanitizer
- GCC 13 with `-Wall -Wextra -pedantic -Werror` and ASan/UBSan
- MinGW GCC 8 with strict warnings